### PR TITLE
feat(unmarshaler): add interface so that children nodes can define custom unmarshal behavior

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -311,6 +311,15 @@ type Metadata struct {
 	Unset []string
 }
 
+// Unmarshaler is an interface that when implemented allows downstream types
+// to customize their behavior when being unmarshaled from a document.
+//
+// Note that the types that implement this interface need to be addressable,
+// meaning they should be pointer or pointer-like values.
+type Unmarshaler interface {
+	UnmarshalMapstructure(interface{}) error
+}
+
 // Decode takes an input structure and uses reflection to translate it to
 // the output structure. output must be a pointer to a map or struct.
 func Decode(input interface{}, output interface{}) error {
@@ -496,6 +505,15 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 			inputVal = reflect.ValueOf(sliceVal) // create nil slice pointer
 		default:
 			inputVal = reflect.Zero(outVal.Type())
+		}
+	}
+
+	if outVal.CanAddr() {
+		// if the output value can be addressed and implements the Unmarshaler
+		// interface, invoke the UnmarshalMapstructure method and return the
+		// error to the user.
+		if v, ok := outVal.Addr().Interface().(Unmarshaler); ok {
+			return v.UnmarshalMapstructure(input)
 		}
 	}
 


### PR DESCRIPTION
This adds the `Unmarshaler` interface where structs have to implement the `UnmarshalMapStructure` method and then on `decoder.Decode`, this will trigger the custom unmarshal method. This will make sure that `mapstructure` is more in line with the rest of the marshaling libraries (like `json` and `yaml`)

