### PR TITLE
Fix typed nil hook support

### DIFF
--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -3,9 +3,11 @@ package mapstructure
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -3309,6 +3311,85 @@ func TestDecoder_ExpandNilStructPointersHookFunc(t *testing.T) {
 	}
 	if _, ok := result.MapStruct["struct"]; !ok {
 		t.Errorf("MapStruct['struct'] expected")
+	}
+}
+
+func TestTypedNilPostHooks(t *testing.T) {
+	type customType1 int
+	type customType2 float64
+	type configType struct {
+		C *customType1 `mapstructure:"c"`
+		A *customType2 `mapstructure:"a"`
+	}
+
+	for i, marshalledConfig := range []map[string]interface{}{
+		{
+			"c": (*customType1)(nil),
+			"a": (*customType2)(floatPtr(42.42)),
+		},
+		{
+			"c": "",
+			"a": "42.42",
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			actual := &configType{}
+			decoder, err := NewDecoder(&DecoderConfig{
+				Result: actual,
+				DecodeHook: ComposeDecodeHookFunc(
+					func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+						var enum customType1
+						if f.Kind() != reflect.String || t != reflect.TypeOf(&enum) {
+							return data, nil
+						}
+						s := data.(string)
+						if s == "" {
+							// Returning an untyped nil here would cause a panic, as `from.Type()`
+							// is invalid for nil.
+							return (*customType1)(nil), nil
+						}
+						n, err := strconv.ParseInt(s, 10, 32)
+						if err != nil {
+							return nil, err
+						}
+						enum = customType1(n)
+						return &enum, nil
+					},
+					func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+						var enum customType2
+						if f.Kind() != reflect.String || t != reflect.TypeOf(&enum) {
+							return data, nil
+						}
+						s := data.(string)
+						if s == "" {
+							return (*customType2)(nil), nil
+						}
+						n, err := strconv.ParseFloat(s, 64)
+						if err != nil {
+							return nil, err
+						}
+						enum = customType2(n)
+						return &enum, nil
+					},
+				),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := decoder.Decode(marshalledConfig); err != nil {
+				t.Fatal(err)
+			}
+
+			expected := &configType{
+				C: nil,
+				A: (*customType2)(floatPtr(42.42)),
+			}
+
+			if !reflect.DeepEqual(expected, actual) {
+				t.Fatalf("Decode() expected: %#v, got: %#v", expected, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
References https://github.com/mitchellh/mapstructure/pull/278

Typed `nil`s which are the result of a type decoding hook seem to result in incorrect decoding behavior. Specifically, the `nil` is turned into an actual value due to the way the `nil` check works, instead of preserving the `nil`. Previously we were returning just untyped `nil`s but ever since https://github.com/mitchellh/mapstructure/pull/205 this seems to no longer be supported while chaining multiple hooks. 

I've added a test which reproduces this issue, and a possible fix. Please also take a look at the comments in the original PR.