### PR TITLE
Remove exposed error type

### DIFF
--- a/error.go
+++ b/error.go
@@ -25,9 +25,8 @@ func (e *joinedError) Error() string {
 		len(e.Errors), strings.Join(points, "\n"))
 }
 
-// WrappedErrors implements the errwrap.Wrapper interface to make this
-// return value more useful with the errwrap and go-multierror libraries.
-func (e *joinedError) WrappedErrors() []error {
+// Unwrap implements the Unwrap function added in Go 1.20.
+func (e *joinedError) Unwrap() []error {
 	if e == nil {
 		return nil
 	}
@@ -40,6 +39,7 @@ func (e *joinedError) WrappedErrors() []error {
 	return result
 }
 
+// TODO: replace with errors.Join when Go 1.20 is minimum version.
 func appendErrors(errors []string, err error) []string {
 	switch e := err.(type) {
 	case *joinedError:

--- a/error.go
+++ b/error.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 )
 
-// Error implements the error interface and can represents multiple
+// joinedError implements the error interface and can represents multiple
 // errors that occur in the course of a single decode.
-type Error struct {
+type joinedError struct {
 	Errors []string
 }
 
-func (e *Error) Error() string {
+func (e *joinedError) Error() string {
 	points := make([]string, len(e.Errors))
 	for i, err := range e.Errors {
 		points[i] = fmt.Sprintf("* %s", err)
@@ -27,7 +27,7 @@ func (e *Error) Error() string {
 
 // WrappedErrors implements the errwrap.Wrapper interface to make this
 // return value more useful with the errwrap and go-multierror libraries.
-func (e *Error) WrappedErrors() []error {
+func (e *joinedError) WrappedErrors() []error {
 	if e == nil {
 		return nil
 	}
@@ -42,7 +42,7 @@ func (e *Error) WrappedErrors() []error {
 
 func appendErrors(errors []string, err error) []string {
 	switch e := err.(type) {
-	case *Error:
+	case *joinedError:
 		return append(errors, e.Errors...)
 	default:
 		return append(errors, e.Error())

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -923,7 +923,7 @@ func (d *Decoder) decodeMapFromMap(name string, dataVal reflect.Value, val refle
 
 	// If we had errors, return those
 	if len(errors) > 0 {
-		return &Error{errors}
+		return &joinedError{errors}
 	}
 
 	return nil
@@ -1184,7 +1184,7 @@ func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) 
 
 	// If there were errors, we return those
 	if len(errors) > 0 {
-		return &Error{errors}
+		return &joinedError{errors}
 	}
 
 	return nil
@@ -1250,7 +1250,7 @@ func (d *Decoder) decodeArray(name string, data interface{}, val reflect.Value) 
 
 	// If there were errors, we return those
 	if len(errors) > 0 {
-		return &Error{errors}
+		return &joinedError{errors}
 	}
 
 	return nil
@@ -1495,7 +1495,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 	}
 
 	if len(errors) > 0 {
-		return &Error{errors}
+		return &joinedError{errors}
 	}
 
 	// Add the unused keys to the list of unused keys if we're tracking metadata

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2323,9 +2323,9 @@ func TestInvalidType(t *testing.T) {
 		t.Fatal("error should exist")
 	}
 
-	derr, ok := err.(*Error)
+	derr, ok := err.(*joinedError)
 	if !ok {
-		t.Fatalf("error should be kind of Error, instead: %#v", err)
+		t.Fatalf("error should be kind of joinedError, instead: %#v", err)
 	}
 
 	if derr.Errors[0] !=
@@ -2342,9 +2342,9 @@ func TestInvalidType(t *testing.T) {
 		t.Fatal("error should exist")
 	}
 
-	derr, ok = err.(*Error)
+	derr, ok = err.(*joinedError)
 	if !ok {
-		t.Fatalf("error should be kind of Error, instead: %#v", err)
+		t.Fatalf("error should be kind of joinedError, instead: %#v", err)
 	}
 
 	if derr.Errors[0] != "cannot parse 'Vuint', -42 overflows uint" {
@@ -2360,9 +2360,9 @@ func TestInvalidType(t *testing.T) {
 		t.Fatal("error should exist")
 	}
 
-	derr, ok = err.(*Error)
+	derr, ok = err.(*joinedError)
 	if !ok {
-		t.Fatalf("error should be kind of Error, instead: %#v", err)
+		t.Fatalf("error should be kind of joinedError, instead: %#v", err)
 	}
 
 	if derr.Errors[0] != "cannot parse 'Vuint', -42.000000 overflows uint" {


### PR DESCRIPTION
This is a breaking change before v2 is tagged.

We are moving towards dropping support for anything below Go 1.20.

Once we are on Go 1.20, we can start using `errors.Join`.