### PR TITLE
feat: when copying into a typed map, decode fields

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -265,6 +265,36 @@ func RecursiveStructToMapHookFunc() DecodeHookFunc {
 	}
 }
 
+// TextMarshallerHookFunc returns a DecodeHookFunc that applies
+// the TextMarshaler interface to the value before decoding.
+func TextMarshallerHookFunc() DecodeHookFuncType {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{},
+	) (interface{}, error) {
+		if t.Kind() != reflect.String {
+			return data, nil
+		}
+
+		// If the value is already a string, just return it (casting if required).
+		if f.Kind() == reflect.String {
+			return reflect.Indirect(reflect.ValueOf(&data)).Elem().String(), nil
+		}
+
+		// Does the value implement the TextMarshaler interface?
+		if marshaler, ok := data.(encoding.TextMarshaler); ok {
+			text, err := marshaler.MarshalText()
+			if err != nil {
+				return nil, err
+			}
+			return string(text), nil
+		}
+
+		return data, nil
+	}
+}
+
 // TextUnmarshallerHookFunc returns a DecodeHookFunc that applies
 // strings to the UnmarshalText function, when the target type
 // implements the encoding.TextUnmarshaler interface

--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -561,6 +561,30 @@ func TestStructToMapHookFuncTabled(t *testing.T) {
 	}
 }
 
+func TestTextMarshallerHookFunc(t *testing.T) {
+	cases := []struct {
+		f, t   reflect.Value
+		result interface{}
+	}{
+		{reflect.ValueOf("42"), reflect.ValueOf(""), "42"},
+		{reflect.ValueOf(big.NewInt(42)), reflect.ValueOf(""), "42"},
+		{reflect.ValueOf(json.Number("42")), reflect.ValueOf(""), "42"},
+		{reflect.ValueOf(42), reflect.ValueOf(0), 42},
+	}
+	for i, tc := range cases {
+		f := TextMarshallerHookFunc()
+		actual, err := DecodeHookExec(f, tc.f, tc.t)
+		if err != nil {
+			t.Fatalf("case %d: unexpected err %#v", i, err)
+		}
+		if !reflect.DeepEqual(actual, tc.result) {
+			t.Fatalf(
+				"case %d: expected %#v, got %#v",
+				i, tc.result, actual)
+		}
+	}
+}
+
 func TestTextUnmarshallerHookFunc(t *testing.T) {
 	type MyString string
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math/big"
 	"reflect"
 	"sort"
 	"strings"
@@ -2674,6 +2675,36 @@ func TestDecode_StructTaggedWithOmitempty_KeepNonEmptyValues(t *testing.T) {
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("Decode() expected: %#v, got: %#v", expected, actual)
+	}
+}
+
+func TestDecode_structToMapWithDecodeHook(t *testing.T) {
+	type From struct {
+		Value *big.Int
+	}
+
+	expected := map[string]string{
+		"Value": "42",
+	}
+
+	target := map[string]string{}
+	decoder, err := NewDecoder(&DecoderConfig{
+		Result:     &target,
+		DecodeHook: TextMarshallerHookFunc(),
+	})
+	if err != nil {
+		t.Fatalf("got error: %s", err)
+	}
+
+	err = decoder.Decode(&From{
+		Value: big.NewInt(42),
+	})
+	if err != nil {
+		t.Fatalf("got error: %s", err)
+	}
+
+	if !reflect.DeepEqual(target, expected) {
+		t.Fatalf("bad: %#v", target)
 	}
 }
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"io"
 	"math/big"
+	"net/netip"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -231,14 +231,6 @@ type TypeConversionResult struct {
 	MapToSlice         []interface{}
 	ArrayToMap         map[string]interface{}
 	MapToArray         [1]interface{}
-}
-
-type Marshalable struct {
-	Int int
-}
-
-func (m Marshalable) MarshalText() ([]byte, error) {
-	return []byte(strconv.Itoa(m.Int)), nil
 }
 
 func TestBasicTypes(t *testing.T) {
@@ -2697,13 +2689,13 @@ func TestDecode_structToMapWithDecodeHook(t *testing.T) {
 	type From struct {
 		*Embedded `mapstructure:",squash"`
 		Bar       *big.Int
-		Baz       Marshalable
+		Baz       netip.Addr
 	}
 
 	expected := map[string]string{
 		"Foo": "1729",
 		"Bar": "42",
-		"Baz": "63",
+		"Baz": "::1",
 	}
 
 	target := map[string]string{}
@@ -2718,7 +2710,7 @@ func TestDecode_structToMapWithDecodeHook(t *testing.T) {
 	err = decoder.Decode(&From{
 		Embedded: &Embedded{Foo: big.NewInt(1729)},
 		Bar:      big.NewInt(42),
-		Baz:      Marshalable{Int: 63},
+		Baz:      netip.IPv6Loopback(),
 	})
 	if err != nil {
 		t.Fatalf("got error: %s", err)


### PR DESCRIPTION
A partial fix for https://github.com/mitchellh/mapstructure/issues/124, at-least for the case when copying into typed maps, eg. map[string]string.

Also added a TextMarshaler decode hook, as the primary use case for this feature is copying structs into map[string]string's in preparation for serialization.