### PR TITLE
Pass appropriate empty Value to hooks

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -489,14 +489,11 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		// Hooks need a valid inputVal, so reset it to zero value of outVal type.
 		switch outputKind {
 		case reflect.Struct, reflect.Map:
-			// create empty map
 			var mapVal map[string]interface{}
-			inputVal = reflect.ValueOf(mapVal)
-			// inputVal = reflect.MakeMap(reflect.TypeOf(mapVal))
+			inputVal = reflect.ValueOf(mapVal) // create nil map pointer
 		case reflect.Slice, reflect.Array:
-			// create nil slice
 			var sliceVal []interface{}
-			inputVal = reflect.ValueOf(sliceVal)
+			inputVal = reflect.ValueOf(sliceVal) // create nil slice pointer
 		default:
 			inputVal = reflect.Zero(outVal.Type())
 		}

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -448,9 +448,7 @@ func isNil(input interface{}) bool {
 		return true
 	}
 	val := reflect.ValueOf(input)
-	k := val.Kind()
-	return (k == reflect.Ptr ||
-		/*k == reflect.Interface || k == reflect.Map || k == reflect.Slice*/ false) && val.IsNil()
+	return val.Kind() == reflect.Ptr && val.IsNil()
 }
 
 // Decodes an unknown data type into a specific reflection value.
@@ -460,12 +458,9 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		outputKind = getKind(outVal)
 		decodeNil  = d.config.DecodeNil && d.cachedDecodeHook != nil
 	)
-	if input != nil {
-		// We need to check here if input is a typed nil. Typed nils won't
-		// match the "input == nil" below so we check that here.
-		if inputVal.Kind() == reflect.Ptr && inputVal.IsNil() {
-			input = nil
-		}
+	if isNil(input) {
+		// Typed nils won't match the "input == nil" below, so reset input.
+		input = nil
 	}
 	if input == nil {
 		// If the data is nil, then we don't set anything, unless ZeroFields is set

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -442,22 +442,15 @@ func (d *Decoder) Decode(input interface{}) error {
 	return err
 }
 
-// A comparison input == nil will fail if input is a typed nil.
-// This function converts a typed nil to an actual, untyped nil.
-func toRealNil(input interface{}) interface{} {
+// isNil returns true if the input is nil or a typed nil pointer.
+func isNil(input interface{}) bool {
 	if input == nil {
-		return nil
+		return true
 	}
 	val := reflect.ValueOf(input)
 	k := val.Kind()
-	if (k == reflect.Ptr ||
-		k == reflect.Interface ||
-		k == reflect.Map ||
-		k == reflect.Slice ||
-		k == reflect.Array) && val.IsNil() {
-		return nil
-	}
-	return input
+	return (k == reflect.Ptr ||
+		/*k == reflect.Interface || k == reflect.Map || k == reflect.Slice*/ false) && val.IsNil()
 }
 
 // Decodes an unknown data type into a specific reflection value.
@@ -467,8 +460,14 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 		outputKind = getKind(outVal)
 		decodeNil  = d.config.DecodeNil && d.cachedDecodeHook != nil
 	)
-	input = toRealNil(input)
-	if input == nil || !inputVal.IsValid() {
+	if input != nil {
+		// We need to check here if input is a typed nil. Typed nils won't
+		// match the "input == nil" below so we check that here.
+		if inputVal.Kind() == reflect.Ptr && inputVal.IsNil() {
+			input = nil
+		}
+	}
+	if input == nil {
 		// If the data is nil, then we don't set anything, unless ZeroFields is set
 		// to true.
 		if d.config.ZeroFields {
@@ -482,29 +481,41 @@ func (d *Decoder) decode(name string, input interface{}, outVal reflect.Value) e
 			return nil
 		}
 	}
+	if !inputVal.IsValid() {
+		if !decodeNil {
+			// If the input value is invalid, then we just set the value
+			// to be the zero value.
+			outVal.Set(reflect.Zero(outVal.Type()))
+			if d.config.Metadata != nil && name != "" {
+				d.config.Metadata.Keys = append(d.config.Metadata.Keys, name)
+			}
+			return nil
+		}
+		// Hooks need a valid inputVal, so reset it to zero value of outVal type.
+		switch outputKind {
+		case reflect.Struct, reflect.Map:
+			// create empty map
+			var mapVal map[string]interface{}
+			inputVal = reflect.ValueOf(mapVal)
+			// inputVal = reflect.MakeMap(reflect.TypeOf(mapVal))
+		case reflect.Slice, reflect.Array:
+			// create nil slice
+			var sliceVal []interface{}
+			inputVal = reflect.ValueOf(sliceVal)
+		default:
+			inputVal = reflect.Zero(outVal.Type())
+		}
+	}
 
 	if d.cachedDecodeHook != nil {
 		// We have a DecodeHook, so let's pre-process the input.
-		if !inputVal.IsValid() {
-			// Hooks need a valid inputVal, so reset it to zero value of outVal type.
-			switch outputKind {
-			case reflect.Struct, reflect.Map:
-				var mapVal map[string]interface{}
-				inputVal = reflect.ValueOf(mapVal)
-			case reflect.Slice, reflect.Array:
-				var sliceVal []interface{}
-				inputVal = reflect.ValueOf(sliceVal)
-			default:
-				inputVal = reflect.Zero(outVal.Type())
-			}
-		}
 		var err error
 		input, err = d.cachedDecodeHook(inputVal, outVal)
 		if err != nil {
 			return fmt.Errorf("error decoding '%s': %w", name, err)
 		}
 	}
-	if toRealNil(input) == nil {
+	if isNil(input) {
 		return nil
 	}
 
@@ -789,8 +800,8 @@ func (d *Decoder) decodeBool(name string, data interface{}, val reflect.Value) e
 		}
 	default:
 		return fmt.Errorf(
-			"'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
-			name, val.Type(), dataVal.Type(), data)
+			"'%s' expected type '%s', got unconvertible type '%#v', value: '%#v'",
+			name, val, dataVal, data)
 	}
 
 	return nil

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -3089,7 +3089,6 @@ func TestDecoder_DecodeNilOption(t *testing.T) {
 	type Transformed struct {
 		Message string
 		When    string
-		Boolean *bool //
 	}
 
 	helloHook := func(reflect.Type, reflect.Type, interface{}) (interface{}, error) {


### PR DESCRIPTION
This is a follow-up to PR #42 that was trying to fix issue #37. The fix included a change to set the input to an empty map
```
		var mapVal map[string]interface{}
		inputVal = reflect.MakeMap(reflect.TypeOf(mapVal))
```
However, it was breaking some of the tests in [OTEL PR ](https://github.com/open-telemetry/opentelemetry-collector/pull/10260) because the map was not expected for non-map target types:
```
'boolean' expected type 'bool', got unconvertible type 'map[string]interface {}', value: 'map[]'
```

Changes:
* add a unit test that catches the above error
* when target type is map/struct or slice/array, set input to a nil pointer to map / slice respectively. Otherwise set it to zero value of the target type
* do not proceed to decoding if the input is nil even after the hook is run
* fix error reporting from one of the decode function - the error itself was panicking by calling `.Type()` on zero value. The same issue likely exists in all other error formatting functions, but I didn't want to bundle too many fixes into this PR.

Tests:
```
$ go test -race -shuffle=on ./...
?   	github.com/go-viper/mapstructure/v2/internal/errors	[no test files]
ok  	github.com/go-viper/mapstructure/v2	1.236s
```

Lints:
```
$ ../../jaegertracing/jaeger/.tools/golangci-lint run
```
(no script in the repo, I used a linter from Jaeger, which uses v1.61.0)