### PR TITLE
[enhancement] Add check for `reflect.Value` in `ComposeDecodeHookFunc`

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -102,7 +102,6 @@ func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 			}
 			if v, ok := data.(reflect.Value); ok {
 				newFrom = v
-				data = v.Interface()
 			} else {
 				newFrom = reflect.ValueOf(data)
 			}

--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -100,7 +100,12 @@ func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 			if err != nil {
 				return nil, err
 			}
-			newFrom = reflect.ValueOf(data)
+			if v, ok := data.(reflect.Value); ok {
+				newFrom = v
+				data = v.Interface()
+			} else {
+				newFrom = reflect.ValueOf(data)
+			}
 		}
 
 		return data, nil

--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -219,6 +219,36 @@ func TestComposeDecodeHookFunc_safe_nofuncs(t *testing.T) {
 	}
 }
 
+func TestComposeDecodeHookFunc_ReflectValueHook(t *testing.T) {
+	reflectValueHook := func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{},
+	) (interface{}, error) {
+		new := data.(string) + "foo"
+		return reflect.ValueOf(new), nil
+	}
+
+	stringHook := func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{},
+	) (interface{}, error) {
+		return data.(string) + "bar", nil
+	}
+
+	f := ComposeDecodeHookFunc(reflectValueHook, stringHook)
+
+	result, err := DecodeHookExec(
+		f, reflect.ValueOf(""), reflect.ValueOf([]byte("")))
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	if result.(string) != "foobar" {
+		t.Fatalf("bad: %#v", result)
+	}
+}
+
 func TestStringToSliceHookFunc(t *testing.T) {
 	f := StringToSliceHookFunc(",")
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/go-viper/mapstructure/issues/37. In this PR, we add a check to `ComposeDecodeHookFunc` to see if the data obtained from the hook is of type `reflect.Value`. If it is, then we don't make an additional `reflect.ValueOf` call. This allows us to not drop into the "value" space which is helpful when decoding nil values as they panic when going from reflect.Value to a value via `.Interface()`. 