### PR TITLE
chore: fix gocritic lint issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
   disable-all: true
   enable:
     - gci
+    - gocritic
     - gofmt
     - gofumpt
     - goimports

--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -278,8 +278,7 @@ func WeaklyTypedHook(
 	data interface{},
 ) (interface{}, error) {
 	dataVal := reflect.ValueOf(data)
-	switch t {
-	case reflect.String:
+	if t == reflect.String {
 		switch f {
 		case reflect.Bool:
 			if dataVal.Bool() {

--- a/mapstructure_bugs_test.go
+++ b/mapstructure_bugs_test.go
@@ -514,7 +514,7 @@ func TestDecodeIntermediateMapsSettable(t *testing.T) {
 				nanos := ts.UnixNano()
 
 				seconds := nanos / 1000000000
-				nanos = nanos % 1000000000
+				nanos %= 1000000000
 
 				return &map[string]interface{}{
 					"Seconds": seconds,

--- a/mapstructure_examples_test.go
+++ b/mapstructure_examples_test.go
@@ -318,8 +318,7 @@ func ExampleDecode_decodeHookFunc() {
 				return data, nil
 			}
 
-			switch f.Kind() {
-			case reflect.String:
+			if f.Kind() == reflect.String {
 				xs := strings.Split(data.(string), "#")
 
 				if len(xs) == 2 {


### PR DESCRIPTION
The PR fixes the following issues:

```
❯ golangci-lint run
decode_hooks.go:281:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
        switch t {
        ^
mapstructure.go:1026:11: elseif: can replace 'else {if cond {}}' with 'else if cond {}' (gocritic)
                        } else {
                               ^
mapstructure.go:786:3: ifElseChain: rewrite if-else to switch statement (gocritic)
                if err == nil {
                ^
mapstructure.go:1010:7: wrapperFunc: suggestion: strings.Contains(tagValue[index+1:], "omitempty") (gocritic)
                        if strings.Index(tagValue[index+1:], "omitempty") != -1 && isEmptyValue(v) {
                           ^
mapstructure.go:1027:8: wrapperFunc: suggestion: strings.Contains(tagValue[index+1:], "remain") (gocritic)
                                if strings.Index(tagValue[index+1:], "remain") != -1 {
                                   ^
mapstructure_bugs_test.go:517:5: assignOp: replace `nanos = nanos % 1000000000` with `nanos %= 1000000000` (gocritic)
                                nanos = nanos % 1000000000
                                ^
mapstructure_examples_test.go:321:4: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
                        switch f.Kind() {
                        ^
```