### PR TITLE
feat(Decoder): Add config flag for merging into existing map values

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -282,6 +282,10 @@ type DecoderConfig struct {
 	// DecodeNil, if set to true, will cause the DecodeHook (if present) to run
 	// even if the input is nil. This can be used to provide default values.
 	DecodeNil bool
+
+	// MergeIntoExisting, if set to true, will merge nested maps or struct with
+	// any already exsting structs or maps in the output.
+	MergeIntoExisting bool
 }
 
 // A Decoder takes a raw interface value and turns it into structured
@@ -1058,12 +1062,31 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 			mType := reflect.MapOf(vKeyType, vElemType)
 			vMap := reflect.MakeMap(mType)
 
-			// Creating a pointer to a map so that other methods can completely
-			// overwrite the map if need be (looking at you decodeMapFromMap). The
-			// indirection allows the underlying map to be settable (CanSet() == true)
-			// where as reflect.MakeMap returns an unsettable map.
-			addrVal := reflect.New(vMap.Type())
-			reflect.Indirect(addrVal).Set(vMap)
+			var addrVal reflect.Value
+			if d.config.MergeIntoExisting {
+				// Check if the map already contains a value for this field.
+				addrVal = valMap.MapIndex(reflect.ValueOf(keyName))
+				if addrVal.IsValid() {
+					// The map already contains a value. Pull it out into a modifiable value.
+					newAddrVal := reflect.New(addrVal.Type())
+					reflect.Indirect(newAddrVal).Set(addrVal)
+					addrVal = newAddrVal
+				} else {
+					// Creating a pointer to a map so that other methods can completely
+					// overwrite the map if need be (looking at you decodeMapFromMap). The
+					// indirection allows the underlying map to be settable (CanSet() == true)
+					// where as reflect.MakeMap returns an unsettable map.
+					addrVal = reflect.New(vMap.Type())
+					reflect.Indirect(addrVal).Set(vMap)
+				}
+			} else {
+				// Creating a pointer to a map so that other methods can completely
+				// overwrite the map if need be (looking at you decodeMapFromMap). The
+				// indirection allows the underlying map to be settable (CanSet() == true)
+				// where as reflect.MakeMap returns an unsettable map.
+				addrVal = reflect.New(vMap.Type())
+				reflect.Indirect(addrVal).Set(vMap)
+			}
 
 			err := d.decode(keyName, x.Interface(), reflect.Indirect(addrVal))
 			if err != nil {


### PR DESCRIPTION
## Description
This pull requests adds a config flag to prevent `mapstructure.Decode()` from clobbering existing values in nested maps in the destination. Instead, the incoming fields will be merged with existing fields in the destination.

## Current behavior example

```go
type Root struct {
	Nested Nested
}

type Nested struct {
	A int
	B int
}

src := A{ Nested: Nested{ A: 42 } }
dst := map[string]any{
	"Nested": map[string]any{
		"A": 123,
		"B": 456,
	},
}

if err := mapstructure.Decode(src, &dst); err != nil {
	panic(err)
}

// dst["Nested"]["A"] is now 42
// dst["Nested"]["B"] no longer exists
```

## New behavior example

```go
type Root struct {
	Nested Nested
}

type Nested struct {
	A int
	B int
}

src := A{ Nested: Nested{ A: 42 } }
dst := map[string]any{
	"Nested": map[string]any{
		"A": 123,
		"B": 456,
	},
}

dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
	MergeIntoExisting: true,
	Result: &dst,
})
if err != nil {
	panic(err)
}

if err := dec.Decode(src); err != nil {
	panic(err)
}

// dst["Nested"]["A"] is now 42
// dst["Nested"]["B"] is still 456

```
