### PR TITLE
decoder: make StringToSliceHookFunc work for any slice

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -145,10 +145,10 @@ func StringToSliceHookFunc(sep string) DecodeHookFunc {
 		t reflect.Type,
 		data interface{},
 	) (interface{}, error) {
-		if f.Kind() != reflect.String {
+		if f.Kind() != reflect.String || t.Kind() != reflect.Slice {
 			return data, nil
 		}
-		if t != reflect.SliceOf(f) {
+		if t.Elem().Kind() == reflect.Uint8 {
 			return data, nil
 		}
 

--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -250,10 +250,11 @@ func TestComposeDecodeHookFunc_ReflectValueHook(t *testing.T) {
 }
 
 func TestStringToSliceHookFunc(t *testing.T) {
-	f := StringToSliceHookFunc(",")
+	f := ComposeDecodeHookFunc(StringToSliceHookFunc(","), StringToBasicTypeHookFunc())
 
 	strValue := reflect.ValueOf("42")
 	sliceValue := reflect.ValueOf([]string{"42"})
+	uintSliceValue := reflect.ValueOf([]uint{1, 2})
 	cases := []struct {
 		f, t   reflect.Value
 		result interface{}
@@ -272,6 +273,12 @@ func TestStringToSliceHookFunc(t *testing.T) {
 			reflect.ValueOf(""),
 			sliceValue,
 			[]string{},
+			false,
+		},
+		{
+			reflect.ValueOf("46,47,48"),
+			uintSliceValue,
+			[]string{"46", "47", "48"},
 			false,
 		},
 	}


### PR DESCRIPTION
Except, slice of bytes. This restores behavior before #6 (commit 84b9bc9).

Fix #69.