### PR TITLE
Feature allow unset pointer

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1465,6 +1465,8 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 			}
 
 			if !rawMapVal.IsValid() {
+				// There was no matching key in the map for the value in
+				// the struct. Remember it for potential errors and metadata.
 				if !(d.config.AllowUnsetPointer && fieldValue.Kind() == reflect.Ptr) {
 					targetValKeysUnused[fieldName] = struct{}{}
 				}

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -222,6 +222,12 @@ type DecoderConfig struct {
 	// will affect all nested structs as well.
 	ErrorUnset bool
 
+	// AllowUnsetPointer, if set to true, will prevent fields with pointer types
+	// from being reported as unset, even if ErrorUnset is true and the field was
+	// not present in the input data. This allows pointer fields to be optional
+	// without triggering an error when they are missing.
+	AllowUnsetPointer bool
+
 	// ZeroFields, if set to true, will zero fields before writing them.
 	// For example, a map will be emptied before decoded values are put in
 	// it. If this is false, a map will be merged.
@@ -1459,9 +1465,9 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 			}
 
 			if !rawMapVal.IsValid() {
-				// There was no matching key in the map for the value in
-				// the struct. Remember it for potential errors and metadata.
-				targetValKeysUnused[fieldName] = struct{}{}
+				if !(d.config.AllowUnsetPointer && fieldValue.Kind() == reflect.Ptr) {
+					targetValKeysUnused[fieldName] = struct{}{}
+				}
 				continue
 			}
 		}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1675,6 +1675,32 @@ func TestDecoder_ErrorUnset(t *testing.T) {
 	}
 }
 
+func TestDecoder_ErrorUnset_AllowUnsetPointer(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vstring": "hello",
+		"foo":     "bar",
+	}
+
+	var result BasicPointer
+	config := &DecoderConfig{
+		ErrorUnset:        true,
+		AllowUnsetPointer: true,
+		Result:            &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = decoder.Decode(input)
+	if err != nil {
+		t.Fatal("error not expected")
+	}
+}
+
 func TestMap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

This pull request adds a config flag `AllowUnsetPointer` to allow pointer fields in structs to be treated as optional during decoding. When enabled, missing pointer fields will not be reported as unset even if `ErrorUnset` is `true`.

This is useful when decoding into structs with optional pointer fields, while still maintaining strict handling (`ErrorUnset`) for required non-pointer fields.

---

## Current behavior example

```go
type Config struct {
	URL  *string
	Port int
}

input := map[string]any{
	"Port": 8080,
}

var cfg Config

dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
	ErrorUnset: true,
	Result:     &cfg,
})
if err != nil {
	panic(err)
}

err = dec.Decode(input)
// err is not nil: "has unset fields: URL"
```
## New behavior with AllowUnsetPointer: true
```go
type Config struct {
	URL  *string
	Port int
}

input := map[string]any{
	"Port": 8080,
}

var cfg Config

dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
	ErrorUnset:        true,
	AllowUnsetPointer: true,
	Result:            &cfg,
})
if err != nil {
	panic(err)
}

err = dec.Decode(input)
// err is nil
// cfg.URL == nil
// cfg.Port == 8080
```