### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The API is the same, so you don't need to change anything else.
 Here is a script that can help you with the migration:
 
 ```shell
-sed -i 's/github.com\/mitchellh\/mapstructure/github.com\/go-viper\/mapstructure\/v2/g' $(find . -type f -name '*.go')
+sed -i 's|github.com/mitchellh/mapstructure|github.com/go-viper/mapstructure/v2|g' $(find . -type f -name '*.go')
 ```
 
 If you need more time to migrate your code, that is absolutely fine.


### PR DESCRIPTION
dont need to escape the / inside sed search and replace command, you can use any placeholder for s/FOO/BAR/g

this makes the command more clear IMHO

there are other possible optimizations to do like

1. use sed with search to be faster `sed -i '/mapstructure/s|...'`
2. use grep to only list the files that contains mapstruture and avoid the vendor directory if any and pipe to xargs

```shell
grep -R -l mapstructure --exclude-dir vendor --include \*.go|xargs sed -i '/mapstructure/s|github.com/mitchellh/mapstructure|github.com/go-viper/mapstructure/v2|g' 
```

however... this starts to became more complex and we don't need this
