### PR TITLE
Use error structs instead of duplicated strings

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -5,40 +5,53 @@ import (
 	"reflect"
 )
 
-// ErrCannotDecode is a generic error type that holds information about
+// DecodeError is a generic error type that holds information about
 // a decoding error together with the name of the field that caused the error.
-type ErrCannotDecode struct {
-	Name string
-	Err  error
+type DecodeError struct {
+	name string
+	err  error
 }
 
-func (e *ErrCannotDecode) Error() string {
-	return fmt.Sprintf("'%s': %s", e.Name, e.Err)
+func newDecodeError(name string, err error) *DecodeError {
+	return &DecodeError{
+		name: name,
+		err:  err,
+	}
 }
 
-// ErrCannotParse extends ErrCannotDecode to include additional information
-// about the expected type and the actual value that could not be parsed.
-type ErrCannotParse struct {
-	ErrCannotDecode
+func (e *DecodeError) Name() string {
+	return e.name
+}
+
+func (e *DecodeError) Unwrap() error {
+	return e.err
+}
+
+func (e *DecodeError) Error() string {
+	return fmt.Sprintf("'%s' %s", e.name, e.err)
+}
+
+// ParseError is an error type that indicates a value could not be parsed
+// into the expected type.
+type ParseError struct {
+	Expected reflect.Value
+	Value    interface{}
+	Err      error
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("cannot parse '%s' as '%s': %s",
+		e.Value, e.Expected.Type(), e.Err)
+}
+
+// UnconvertibleTypeError is an error type that indicates a value could not be
+// converted to the expected type.
+type UnconvertibleTypeError struct {
 	Expected reflect.Value
 	Value    interface{}
 }
 
-func (e *ErrCannotParse) Error() string {
-	return fmt.Sprintf("'%s' cannot parse '%s' as '%s': %s",
-		e.Name, e.Value, e.Expected.Type(), e.Err)
-}
-
-// ErrUnconvertibleType is an error type that indicates a value could not be
-// converted to the expected type. It includes the name of the field, the
-// expected type, and the actual value that was attempted to be converted.
-type ErrUnconvertibleType struct {
-	Name     string
-	Expected reflect.Value
-	Value    interface{}
-}
-
-func (e *ErrUnconvertibleType) Error() string {
-	return fmt.Sprintf("'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
-		e.Name, e.Expected.Type(), reflect.TypeOf(e.Value), e.Value)
+func (e *UnconvertibleTypeError) Error() string {
+	return fmt.Sprintf("expected type '%s', got unconvertible type '%s', value: '%v'",
+		e.Expected.Type(), reflect.TypeOf(e.Value), e.Value)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,44 @@
+package mapstructure
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ErrCannotDecode is a generic error type that holds information about
+// a decoding error together with the name of the field that caused the error.
+type ErrCannotDecode struct {
+	Name string
+	Err  error
+}
+
+func (e *ErrCannotDecode) Error() string {
+	return fmt.Sprintf("'%s': %s", e.Name, e.Err)
+}
+
+// ErrCannotParse extends ErrCannotDecode to include additional information
+// about the expected type and the actual value that could not be parsed.
+type ErrCannotParse struct {
+	ErrCannotDecode
+	Expected reflect.Value
+	Value    interface{}
+}
+
+func (e *ErrCannotParse) Error() string {
+	return fmt.Sprintf("'%s' cannot parse '%s' as '%s': %s",
+		e.Name, e.Value, e.Expected.Type(), e.Err)
+}
+
+// ErrUnconvertibleType is an error type that indicates a value could not be
+// converted to the expected type. It includes the name of the field, the
+// expected type, and the actual value that was attempted to be converted.
+type ErrUnconvertibleType struct {
+	Name     string
+	Expected reflect.Value
+	Value    interface{}
+}
+
+func (e *ErrUnconvertibleType) Error() string {
+	return fmt.Sprintf("'%s' expected type '%s', got unconvertible type '%s', value: '%v'",
+		e.Name, e.Expected.Type(), reflect.TypeOf(e.Value), e.Value)
+}

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2604,11 +2604,11 @@ func TestInvalidType(t *testing.T) {
 
 	errs := derr.Unwrap()
 
-	var unconvertibleErr *ErrUnconvertibleType
-	if !errors.As(errs[0], &unconvertibleErr) {
+	var decoderErr *DecodeError
+	if !errors.As(errs[0], &decoderErr) {
 		t.Errorf("got unexpected error: %s", err)
-	} else if unconvertibleErr.Expected.Type() != reflect.TypeOf("") {
-		t.Errorf("expected type should be string, got: %s", unconvertibleErr.Expected)
+	} else if errors.Is(decoderErr.Unwrap(), &UnconvertibleTypeError{}) {
+		t.Errorf("error should be UnconvertibleTypeError, got: %s", decoderErr.Unwrap())
 	}
 
 	inputNegIntUint := map[string]interface{}{
@@ -2626,11 +2626,10 @@ func TestInvalidType(t *testing.T) {
 
 	errs = derr.Unwrap()
 
-	var parseErr *ErrCannotParse
-	if !errors.As(errs[0], &parseErr) {
+	if !errors.As(errs[0], &decoderErr) {
 		t.Errorf("got unexpected error: %s", err)
-	} else if parseErr.Expected.Type() != reflect.TypeOf(uint(0)) {
-		t.Errorf("expected type should be uint, got: %s", parseErr.Expected)
+	} else if errors.Is(decoderErr.Unwrap(), &ParseError{}) {
+		t.Errorf("error should be ParseError, got: %s", decoderErr.Unwrap())
 	}
 
 	inputNegFloatUint := map[string]interface{}{
@@ -2648,10 +2647,8 @@ func TestInvalidType(t *testing.T) {
 
 	errs = derr.Unwrap()
 
-	if !errors.As(errs[0], &parseErr) {
+	if !errors.As(errs[0], &decoderErr) {
 		t.Errorf("got unexpected error: %s", err)
-	} else if parseErr.Expected.Type() != reflect.TypeOf(uint(0)) {
-		t.Errorf("expected type should be uint, got: %s", parseErr.Expected)
 	}
 }
 

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -2604,8 +2604,11 @@ func TestInvalidType(t *testing.T) {
 
 	errs := derr.Unwrap()
 
-	if errs[0].Error() != "'Vstring' expected type 'string', got unconvertible type 'int', value: '42'" {
+	var unconvertibleErr *ErrUnconvertibleType
+	if !errors.As(errs[0], &unconvertibleErr) {
 		t.Errorf("got unexpected error: %s", err)
+	} else if unconvertibleErr.Expected.Type() != reflect.TypeOf("") {
+		t.Errorf("expected type should be string, got: %s", unconvertibleErr.Expected)
 	}
 
 	inputNegIntUint := map[string]interface{}{
@@ -2623,8 +2626,11 @@ func TestInvalidType(t *testing.T) {
 
 	errs = derr.Unwrap()
 
-	if errs[0].Error() != "cannot parse 'Vuint', -42 overflows uint" {
+	var parseErr *ErrCannotParse
+	if !errors.As(errs[0], &parseErr) {
 		t.Errorf("got unexpected error: %s", err)
+	} else if parseErr.Expected.Type() != reflect.TypeOf(uint(0)) {
+		t.Errorf("expected type should be uint, got: %s", parseErr.Expected)
 	}
 
 	inputNegFloatUint := map[string]interface{}{
@@ -2642,8 +2648,10 @@ func TestInvalidType(t *testing.T) {
 
 	errs = derr.Unwrap()
 
-	if errs[0].Error() != "cannot parse 'Vuint', -42.000000 overflows uint" {
+	if !errors.As(errs[0], &parseErr) {
 		t.Errorf("got unexpected error: %s", err)
+	} else if parseErr.Expected.Type() != reflect.TypeOf(uint(0)) {
+		t.Errorf("expected type should be uint, got: %s", parseErr.Expected)
 	}
 }
 


### PR DESCRIPTION
Currently, all errors are just strings. They have all one thing in common: They identify a field that caused the error. Therefore I created `DecodeError` struct that hold this information.

The next batch of errors is about parsing a certain type. They all have the information about why the parsing failed and additionally what was the expected and actual value. Therefore I created `ParseError`.

Last similarity in all errors that I found was when handling unconvertible types. In contrast to parsing errors, they do not have any parsing error as the appropriate parser could not be even found. Therefore I created `UnconvertibleTypeError` for them.

This allows us to get detailed errors about what went wrong in the decoding process, it helps with the code clarity - lot of duplicate messages were joined to a single struct. And more importantly, what was my main motivation, it allows me to join the errors together when I use custom nested decoder.