### PR TITLE
Fix decode hooks with null values in remaining data

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -92,6 +92,11 @@ func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
 	}
 	return func(f reflect.Value, t reflect.Value) (any, error) {
 		var err error
+
+		if f.Kind() == reflect.Interface && f.IsNil() {
+			return nil, nil
+		}
+
 		data := f.Interface()
 
 		newFrom := f

--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -126,6 +126,33 @@ func TestComposeDecodeHookFunc(t *testing.T) {
 	}
 }
 
+func TestComposeDecodeHookFuncNil(t *testing.T) {
+	f1 := func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data any,
+	) (any, error) {
+		return data, nil
+	}
+
+	f2 := func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data any,
+	) (any, error) {
+		return data, nil
+	}
+
+	f := ComposeDecodeHookFunc(f1, f2)
+
+	result, err := DecodeHookExec(
+		f, reflect.ValueOf(new(any)).Elem(), reflect.Value{})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	_ = result
+}
+
 func TestComposeDecodeHookFunc_err(t *testing.T) {
 	f1 := func(reflect.Kind, reflect.Kind, any) (any, error) {
 		return nil, errors.New("foo")


### PR DESCRIPTION
Adds an early exit if composed decode hooks are processing a field which is has an untyped nil value.

Fixes #121
