### PR TITLE
feature: allow hooks to override nested struct type

### DIFF
--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -1002,6 +1002,65 @@ func TestStructToMapHookFuncTabled(t *testing.T) {
 	}
 }
 
+func TestNestedStructFieldTypeOverride(t *testing.T) {
+	type Struct struct {
+		Time time.Time `mapstructure:"time"`
+	}
+
+	input := Struct{
+		Time: time.Now(),
+	}
+
+	var actualNoHook map[string]any
+
+	d, err := NewDecoder(&DecoderConfig{Result: &actualNoHook})
+	if err != nil {
+		t.Fatalf("unexpected err %#v", err)
+	}
+
+	expectedNoHook := map[string]any{}
+
+	err = d.Decode(input)
+	if err != nil {
+		t.Fatalf("unexpected err %#v", err)
+	}
+
+	if !reflect.DeepEqual(expectedNoHook, actualNoHook["time"]) {
+		t.Fatalf("expected %#v, got %#v", expectedNoHook, actualNoHook["time"])
+	}
+
+	var actualHook map[string]any
+
+	d, err = NewDecoder(&DecoderConfig{
+		Result: &actualHook,
+		DecodeHook: func(from, to reflect.Type, data any) (any, error) {
+			if tm, ok := data.(time.Time); ok {
+				return tm.Format(time.RFC3339), nil
+			}
+
+			if tm, ok := data.(*time.Time); ok {
+				return tm.Format(time.RFC3339), nil
+			}
+
+			return data, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err %#v", err)
+	}
+
+	expectedHook := input.Time.Format(time.RFC3339)
+
+	err = d.Decode(input)
+	if err != nil {
+		t.Fatalf("unexpected err %#v", err)
+	}
+
+	if !reflect.DeepEqual(expectedHook, actualHook["time"]) {
+		t.Fatalf("expected %#v, got %#v", expectedHook, actualHook["time"])
+	}
+}
+
 func TestTextUnmarshallerHookFunc(t *testing.T) {
 	type MyString string
 

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1220,6 +1220,21 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 			keyName = tagValue
 		}
 
+		if d.cachedDecodeHook != nil {
+			mapelem := reflect.New(valMap.Type().Elem()).Elem()
+
+			input, err := d.cachedDecodeHook(v, mapelem)
+			if err != nil {
+				return fmt.Errorf("error decoding '%s': %w", name, err)
+			}
+
+			if !reflect.DeepEqual(input, v.Interface()) {
+				valMap.SetMapIndex(reflect.ValueOf(keyName), reflect.ValueOf(input))
+
+				continue
+			}
+		}
+
 		switch v.Kind() {
 		// this is an embedded struct, so handle it differently
 		case reflect.Struct:


### PR DESCRIPTION
Re-implementation of #43, #36

Currently hooks are only queried after target type for nested struct is determined which cannot be changed from map, this MR introduces hook dispatch early at struct field processing, allowing to replace field with type other than map.

Main use-case is rendering `time.Time` (which is a struct with no exported fields) as a string.

Partially addresses #165 (at least allows proposed hook solution to function as expected).

Changes conflict with #176, a rebase of other will be necessary if either is merged.