### PR TITLE
decode: skip `mapstructure:"-"` fields so ErrorUnset doesn't flag them

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1663,6 +1663,11 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 			continue
 		}
 		tagValue = strings.SplitN(tagValue, ",", 2)[0]
+		// `mapstructure:"-"` opts the field out of decoding entirely. Don't
+		// then turn around and report a "-" key as Unset/missing.
+		if tagValue == "-" {
+			continue
+		}
 		if tagValue != "" {
 			fieldName = tagValue
 		} else {

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -1714,6 +1714,34 @@ func TestDecoder_ErrorUnset(t *testing.T) {
 	}
 }
 
+func TestDecoder_ErrorUnset_IgnoresDashTaggedField(t *testing.T) {
+	// Regression for #89: a field tagged `mapstructure:"-"` is opted out
+	// of decoding, so ErrorUnset shouldn't flag it as missing.
+	t.Parallel()
+
+	input := map[string]any{
+		"foo": "bar",
+	}
+
+	var result struct {
+		Foo string `mapstructure:"foo"`
+		Bar string `mapstructure:"-"`
+	}
+	config := &DecoderConfig{
+		ErrorUnset: true,
+		Result:     &result,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDecoder_ErrorUnset_AllowUnsetPointer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #89.

`mapstructure:"-"` means a field is opted out of decoding, but the decoder still walked it during struct iteration and added the literal `"-"` key to `Metadata.Unset`, which made `ErrorUnset` trip on it. Honour the tag by continuing past the field, matching how the encoder already handles it.