### PR TITLE
fix: don't let case-insensitive fallback reuse an exactly-matched key

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1681,6 +1681,14 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 					continue
 				}
 
+				// Skip keys already consumed by another field's exact
+				// match, so a case-insensitive fallback can't claim the
+				// same key a second time (e.g. fields `Name` and `NAME`
+				// both matching the key "name").
+				if _, unused := dataValKeysUnused[dataValKey.Interface()]; !unused {
+					continue
+				}
+
 				if d.config.MatchName(mK, fieldName) {
 					rawMapKey = dataValKey
 					rawMapVal = dataVal.MapIndex(dataValKey)

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -4673,3 +4673,25 @@ func TestUnmarshaler_StructToMap(t *testing.T) {
 		t.Errorf("expected Age 30, got %v", result["Age"])
 	}
 }
+
+func TestDecode_caseInsensitiveDuplicateKey(t *testing.T) {
+	// A case-insensitive fallback must not claim a key that another field
+	// already matched exactly: decoding {"name": ...} into a struct with both
+	// `name` and `NAME` fields should populate only the exact match.
+	type Result struct {
+		Name string `mapstructure:"name"`
+		NAME string `mapstructure:"NAME"`
+	}
+
+	var result Result
+	if err := Decode(map[string]interface{}{"name": "lower"}, &result); err != nil {
+		t.Fatalf("got an err: %s", err)
+	}
+
+	if result.Name != "lower" {
+		t.Errorf("Name should be 'lower', got: %#v", result.Name)
+	}
+	if result.NAME != "" {
+		t.Errorf("NAME should be empty, got: %#v", result.NAME)
+	}
+}


### PR DESCRIPTION
Fixes #75.

When a struct has two fields whose names differ only by case, decoding a map that contains one of them populates **both** fields:

```go
type Result struct {
    Name string `mapstructure:"name"`
    NAME string `mapstructure:"NAME"`
}
var r Result
mapstructure.Decode(map[string]any{"name": "lower"}, &r)
// got:  {Name:"lower" NAME:"lower"}
// want: {Name:"lower" NAME:""}
```

In `decodeStructFromMap`, the `Name` field matches the key `"name"` exactly and removes it from `dataValKeysUnused`. The `NAME` field has no exact key, so it falls into the case-insensitive search — which iterates **all** keys and matches `"name"` again via `MatchName`, even though it was already consumed. (`encoding/json` gives the value only to the exact match.)

The fix skips keys that are no longer in `dataValKeysUnused` during the case-insensitive fallback, so each map key is claimed by at most one field, and the exact match wins.

Added `TestDecode_caseInsensitiveDuplicateKey`; it fails before the fix (`NAME` is `"lower"`) and passes after. Existing `TestDecode*` tests still pass.
