### PR TITLE
fix: trim spaces in string decode hooks

### DIFF
--- a/decode_hooks.go
+++ b/decode_hooks.go
@@ -223,8 +223,8 @@ func StringToTimeDurationHookFunc() DecodeHookFunc {
 			return data, nil
 		}
 
-		// Convert it by parsing
-		d, err := time.ParseDuration(data.(string))
+		// Convert it by parsing (trim spaces common in config/env values)
+		d, err := time.ParseDuration(strings.TrimSpace(data.(string)))
 
 		return d, wrapTimeParseDurationError(err)
 	}
@@ -244,7 +244,7 @@ func StringToTimeLocationHookFunc() DecodeHookFunc {
 		if t != reflect.TypeOf(time.Local) {
 			return data, nil
 		}
-		d, err := time.LoadLocation(data.(string))
+		d, err := time.LoadLocation(strings.TrimSpace(data.(string)))
 
 		return d, wrapTimeParseLocationError(err)
 	}
@@ -266,7 +266,7 @@ func StringToURLHookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		u, err := url.Parse(data.(string))
+		u, err := url.Parse(strings.TrimSpace(data.(string)))
 
 		return u, wrapUrlError(err)
 	}
@@ -288,7 +288,7 @@ func StringToIPHookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		ip := net.ParseIP(data.(string))
+		ip := net.ParseIP(strings.TrimSpace(data.(string)))
 		if ip == nil {
 			return net.IP{}, fmt.Errorf("failed parsing ip")
 		}
@@ -334,7 +334,7 @@ func StringToTimeHookFunc(layout string) DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		ti, err := time.Parse(layout, data.(string))
+		ti, err := time.Parse(layout, strings.TrimSpace(data.(string)))
 
 		return ti, wrapTimeParseError(err)
 	}
@@ -524,7 +524,7 @@ func StringToInt8HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		i64, err := strconv.ParseInt(data.(string), 0, 8)
+		i64, err := strconv.ParseInt(strings.TrimSpace(data.(string)), 0, 8)
 		return int8(i64), wrapStrconvNumError(err)
 	}
 }
@@ -538,7 +538,7 @@ func StringToUint8HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		u64, err := strconv.ParseUint(data.(string), 0, 8)
+		u64, err := strconv.ParseUint(strings.TrimSpace(data.(string)), 0, 8)
 		return uint8(u64), wrapStrconvNumError(err)
 	}
 }
@@ -552,7 +552,7 @@ func StringToInt16HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		i64, err := strconv.ParseInt(data.(string), 0, 16)
+		i64, err := strconv.ParseInt(strings.TrimSpace(data.(string)), 0, 16)
 		return int16(i64), wrapStrconvNumError(err)
 	}
 }
@@ -566,7 +566,7 @@ func StringToUint16HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		u64, err := strconv.ParseUint(data.(string), 0, 16)
+		u64, err := strconv.ParseUint(strings.TrimSpace(data.(string)), 0, 16)
 		return uint16(u64), wrapStrconvNumError(err)
 	}
 }
@@ -580,7 +580,7 @@ func StringToInt32HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		i64, err := strconv.ParseInt(data.(string), 0, 32)
+		i64, err := strconv.ParseInt(strings.TrimSpace(data.(string)), 0, 32)
 		return int32(i64), wrapStrconvNumError(err)
 	}
 }
@@ -594,7 +594,7 @@ func StringToUint32HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		u64, err := strconv.ParseUint(data.(string), 0, 32)
+		u64, err := strconv.ParseUint(strings.TrimSpace(data.(string)), 0, 32)
 		return uint32(u64), wrapStrconvNumError(err)
 	}
 }
@@ -608,7 +608,7 @@ func StringToInt64HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		i64, err := strconv.ParseInt(data.(string), 0, 64)
+		i64, err := strconv.ParseInt(strings.TrimSpace(data.(string)), 0, 64)
 		return int64(i64), wrapStrconvNumError(err)
 	}
 }
@@ -622,7 +622,7 @@ func StringToUint64HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		u64, err := strconv.ParseUint(data.(string), 0, 64)
+		u64, err := strconv.ParseUint(strings.TrimSpace(data.(string)), 0, 64)
 		return uint64(u64), wrapStrconvNumError(err)
 	}
 }
@@ -636,7 +636,7 @@ func StringToIntHookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		i64, err := strconv.ParseInt(data.(string), 0, 0)
+		i64, err := strconv.ParseInt(strings.TrimSpace(data.(string)), 0, 0)
 		return int(i64), wrapStrconvNumError(err)
 	}
 }
@@ -650,7 +650,7 @@ func StringToUintHookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		u64, err := strconv.ParseUint(data.(string), 0, 0)
+		u64, err := strconv.ParseUint(strings.TrimSpace(data.(string)), 0, 0)
 		return uint(u64), wrapStrconvNumError(err)
 	}
 }
@@ -664,7 +664,7 @@ func StringToFloat32HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		f64, err := strconv.ParseFloat(data.(string), 32)
+		f64, err := strconv.ParseFloat(strings.TrimSpace(data.(string)), 32)
 		return float32(f64), wrapStrconvNumError(err)
 	}
 }
@@ -678,7 +678,7 @@ func StringToFloat64HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		f64, err := strconv.ParseFloat(data.(string), 64)
+		f64, err := strconv.ParseFloat(strings.TrimSpace(data.(string)), 64)
 		return f64, wrapStrconvNumError(err)
 	}
 }
@@ -692,7 +692,7 @@ func StringToBoolHookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		b, err := strconv.ParseBool(data.(string))
+		b, err := strconv.ParseBool(strings.TrimSpace(data.(string)))
 		return b, wrapStrconvNumError(err)
 	}
 }
@@ -718,7 +718,7 @@ func StringToComplex64HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		c128, err := strconv.ParseComplex(data.(string), 64)
+		c128, err := strconv.ParseComplex(strings.TrimSpace(data.(string)), 64)
 		return complex64(c128), wrapStrconvNumError(err)
 	}
 }
@@ -732,7 +732,7 @@ func StringToComplex128HookFunc() DecodeHookFunc {
 		}
 
 		// Convert it by parsing
-		c128, err := strconv.ParseComplex(data.(string), 128)
+		c128, err := strconv.ParseComplex(strings.TrimSpace(data.(string)), 128)
 		return c128, wrapStrconvNumError(err)
 	}
 }

--- a/decode_hooks_test.go
+++ b/decode_hooks_test.go
@@ -602,6 +602,10 @@ func TestStringToTimeDurationHookFunc(t *testing.T) {
 			{"5µs", 5 * time.Microsecond},              // Unicode micro symbol is valid
 			{"5.s", 5 * time.Second},                   // Trailing decimal is valid
 			{"5s5m5s", 10*time.Second + 5*time.Minute}, // Duplicate units are valid
+			{" 5s ", 5 * time.Second},                   // Leading/trailing spaces trimmed
+			{"\t10ms\n", 10 * time.Millisecond},          // Tab/newline trimmed
+			{"\r1h\r", time.Hour},                        // Carriage return trimmed
+			{"5s ", 5 * time.Second},                     // Trailing space trimmed
 		},
 		fail: []decodeHookFailureTestCase[string, time.Duration]{
 			{"5"},        // Missing unit
@@ -612,10 +616,6 @@ func TestStringToTimeDurationHookFunc(t *testing.T) {
 			{"5..5s"},    // Multiple decimal points
 			{"++5s"},     // Double plus sign
 			{"--5s"},     // Double minus sign
-			{" 5s "},     // Leading/trailing whitespace not handled
-			{"\t10ms\n"}, // Tab/newline whitespace not handled
-			{"\r1h\r"},   // Carriage return whitespace not handled
-			{"5s "},      // Trailing space after unit
 			{" 5 s"},     // Space before unit
 			{"5 s 10 m"}, // Spaces in combined duration
 			{"∞s"},       // Unicode infinity symbol
@@ -1229,9 +1229,6 @@ func TestStringToInt8HookFunc(t *testing.T) {
 			{"42.5"},                   // Float
 			{"abc"},                    // Non-numeric
 			{""},                       // Empty string
-			{" 42 "},                   // Whitespace not handled by strconv
-			{"\t42\n"},                 // Whitespace not handled by strconv
-			{"\r42\r"},                 // Whitespace not handled by strconv
 			{"0x"},                     // Invalid hex
 			{"0b"},                     // Invalid binary
 			{"0o"},                     // Invalid octal
@@ -1290,9 +1287,6 @@ func TestStringToUint8HookFunc(t *testing.T) {
 			{"0b"},          // Invalid binary
 			{"0o"},          // Invalid octal
 			{"++42"},        // Double plus
-			{" 42 "},        // Whitespace not handled by strconv
-			{"\t42\n"},      // Whitespace not handled by strconv
-			{"\r42\r"},      // Whitespace not handled by strconv
 			{"42abc"},       // Trailing non-numeric
 			{"abc42"},       // Leading non-numeric
 			{"42 43"},       // Multiple numbers
@@ -1556,12 +1550,6 @@ func TestStringToFloat32HookFunc(t *testing.T) {
 			{"1.2.3"},    // Multiple dots
 			{"1..2"},     // Double dots
 			{"."},        // Just a dot
-			{" 42.5 "},   // Whitespace not handled by strconv
-			{"\t42.5\n"}, // Whitespace not handled by strconv
-			{"\r42.5\r"}, // Whitespace not handled by strconv
-			{" 42.5 "},   // Whitespace not handled by strconv
-			{"\t42.5\n"}, // Whitespace not handled by strconv
-			{"\r42.5\r"}, // Whitespace not handled by strconv
 			{"1e1e1"},    // Multiple exponents
 			{"∞"},        // Unicode infinity
 			{"NaΝ"},      // Unicode NaN lookalike
@@ -1792,12 +1780,6 @@ func TestStringToComplex64HookFunc(t *testing.T) {
 			{"1+1..2i"},        // Double dots in imaginary
 			{".+.i"},           // Just dots
 			{"1e1e1+1i"},       // Multiple exponents in real
-			{" 42+42i "},       // Whitespace not handled by strconv
-			{"\t42i\n"},        // Whitespace not handled by strconv
-			{"\r42\r"},         // Whitespace not handled by strconv
-			{" 42+42i "},       // Whitespace not handled by strconv
-			{"\t42i\n"},        // Whitespace not handled by strconv
-			{"\r42\r"},         // Whitespace not handled by strconv
 			{"1+1e1e1i"},       // Multiple exponents in imaginary
 			{"∞"},              // Unicode infinity
 			{"∞+∞i"},           // Unicode infinity complex
@@ -1862,6 +1844,9 @@ func TestStringToBoolHookFunc(t *testing.T) {
 			{"f", false},     // Single character false (lowercase)
 			{"F", false},     // Single character false (uppercase)
 			{"0", false},     // Numeric false
+			{" true ", true},  // Leading/trailing spaces trimmed
+			{"\ttrue\n", true}, // Tab/newline trimmed
+			{"\rfalse\r", false}, // Carriage return trimmed
 		},
 		fail: []decodeHookFailureTestCase[string, bool]{
 			{""},           // Empty string
@@ -1887,11 +1872,6 @@ func TestStringToBoolHookFunc(t *testing.T) {
 			{"fasle"},      // Typo in false
 			{"tru"},        // Incomplete true
 			{"fals"},       // Incomplete false
-			{" true "},     // Whitespace not handled by strconv.ParseBool
-			{"\ttrue\n"},   // Tab and newline whitespace
-			{"\rfalse\r"},  // Carriage return whitespace
-			{" 1 "},        // Whitespace around numeric true
-			{" 0 "},        // Whitespace around numeric false
 			{"∞"},          // Unicode infinity symbol
 			{"тrue"},       // Cyrillic lookalike characters
 		},
@@ -2170,5 +2150,28 @@ func TestErrorLeakageDecodeHook(t *testing.T) {
 		} else {
 			t.Logf("case %d: got safe error: %v", i, err)
 		}
+	}
+}
+
+func TestStringToTimeDurationHookFuncTrimSpace(t *testing.T) {
+	f := StringToTimeDurationHookFunc()
+	result, err := DecodeHookExec(f, reflect.ValueOf(" 2s "), reflect.ValueOf(time.Duration(0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != 2*time.Second {
+		t.Fatalf("got %v", result)
+	}
+}
+
+func TestStringToIPHookFuncTrimSpace(t *testing.T) {
+	f := StringToIPHookFunc()
+	result, err := DecodeHookExec(f, reflect.ValueOf(" 127.0.0.1 "), reflect.ValueOf(net.IP{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ip, ok := result.(net.IP)
+	if !ok || !ip.Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("got %v", result)
 	}
 }


### PR DESCRIPTION
## Summary

String decode hooks failed on values like `" 2s "` or `" 127.0.0.1 "` because parsers do not trim whitespace.

Apply `strings.TrimSpace` in the string-to-duration/IP/time/URL/numeric/bool hooks.

## Test plan

- [x] dedicated trim tests
- [x] full package tests