### PR TITLE
perf: cache and optimize struct tag processing

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -205,6 +205,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/go-viper/mapstructure/v2/internal/errors"
 )
@@ -1570,8 +1571,10 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 	// Compile the list of all the fields that we're going to be decoding
 	// from all the structs.
 	type field struct {
-		field reflect.StructField
-		val   reflect.Value
+		name string
+		// nameVal is a cached reflect.ValueOf(name)
+		nameVal reflect.Value
+		val     reflect.Value
 	}
 
 	// remainField is set to a valid field set with the "remain" tag if
@@ -1645,31 +1648,26 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 
 			// Build our field
 			if remain {
-				remainField = &field{fieldType, fieldVal}
+				remainField = &field{val: fieldVal}
 			} else {
 				// Normal struct field, store it away
-				fields = append(fields, field{fieldType, fieldVal})
+				tagName, hasTagValue := getFieldKey(fieldType, d.config.TagName)
+				if !hasTagValue && d.config.IgnoreUntaggedFields {
+					continue
+				}
+				fieldName := tagName
+				if fieldName == "" {
+					fieldName = d.config.MapFieldName(fieldType.Name)
+				}
+				fields = append(fields, field{fieldName, getStringValue(fieldName), fieldVal})
 			}
 		}
 	}
 
-	// for fieldType, field := range fields {
 	for _, f := range fields {
-		field, fieldValue := f.field, f.val
-		fieldName := field.Name
+		fieldName, fieldValue := f.name, f.val
 
-		tagValue, _ := getTagValue(field, d.config.TagName)
-		if tagValue == "" && d.config.IgnoreUntaggedFields {
-			continue
-		}
-		tagValue = strings.SplitN(tagValue, ",", 2)[0]
-		if tagValue != "" {
-			fieldName = tagValue
-		} else {
-			fieldName = d.config.MapFieldName(fieldName)
-		}
-
-		rawMapKey := reflect.ValueOf(fieldName)
+		rawMapKey := f.nameVal
 		rawMapVal := dataVal.MapIndex(rawMapKey)
 		if !rawMapVal.IsValid() {
 			// Do a slower search by iterating over each key and
@@ -1691,7 +1689,7 @@ func (d *Decoder) decodeStructFromMap(name string, dataVal, val reflect.Value) e
 			if !rawMapVal.IsValid() {
 				// There was no matching key in the map for the value in
 				// the struct. Remember it for potential errors and metadata.
-				if !(d.config.AllowUnsetPointer && fieldValue.Kind() == reflect.Ptr) {
+				if shouldTrackUnused(d.config, fieldValue) {
 					targetValKeysUnused[fieldName] = struct{}{}
 				}
 				continue
@@ -1876,13 +1874,71 @@ func hasAnyTag(field reflect.StructField, tagName string) bool {
 	return ok
 }
 
-func getTagParts(field reflect.StructField, tagName string) []string {
-	tagValue, ok := getTagValue(field, tagName)
-	if !ok {
-		return nil
-	}
-	return strings.Split(tagValue, ",")
+func shouldTrackUnused(c *DecoderConfig, fieldValue reflect.Value) bool {
+	return (c.ErrorUnset || c.Metadata != nil) &&
+		!(c.AllowUnsetPointer && fieldValue.Kind() == reflect.Ptr)
 }
+
+// getFieldKey memoizes getTagValue(field, tagName)[0], ie. the map key to be
+// used to look up the field's value in the input.
+func getFieldKey(field reflect.StructField, tagName string) (string, bool) {
+	type cacheVal struct {
+		key string
+		ok  bool
+	}
+	key := tagKey{field.Tag, tagName}
+	if v, ok := fieldKeyCache.Load(key); ok {
+		r := v.(cacheVal)
+		return r.key, r.ok
+	}
+
+	var r cacheVal
+	if tagValue, ok := getTagValue(field, tagName); ok && tagValue != "" {
+		r = cacheVal{strings.SplitN(tagValue, ",", 2)[0], true}
+	}
+
+	fieldKeyCache.Store(key, r)
+	return r.key, r.ok
+}
+
+type tagKey struct {
+	tag     reflect.StructTag
+	tagName string // [DecoderConfig.TagName]
+}
+
+var fieldKeyCache sync.Map // owned by getFieldKey
+
+// getStringValue memoizes reflect.ValueOf(s).
+func getStringValue(s string) reflect.Value {
+	if v, ok := stringValueCache.Load(s); ok {
+		return v.(reflect.Value)
+	}
+
+	rv := reflect.ValueOf(s)
+
+	stringValueCache.Store(s, rv)
+	return rv
+}
+
+var stringValueCache sync.Map // owned by getStringValue
+
+// getTagParts memoizes getTagValue(field, tagName), split by ","
+func getTagParts(field reflect.StructField, tagName string) []string {
+	key := tagKey{field.Tag, tagName}
+	if v, ok := tagPartsCache.Load(key); ok {
+		return v.([]string)
+	}
+
+	var parts []string
+	if tagValue, ok := getTagValue(field, tagName); ok {
+		parts = strings.Split(tagValue, ",")
+	}
+
+	tagPartsCache.Store(key, parts)
+	return parts
+}
+
+var tagPartsCache sync.Map // owned by getTagParts
 
 func getTagValue(field reflect.StructField, tagName string) (string, bool) {
 	for _, name := range splitTagNames(tagName) {
@@ -1894,7 +1950,7 @@ func getTagValue(field reflect.StructField, tagName string) (string, bool) {
 }
 
 func splitTagNames(tagName string) []string {
-	if tagName == "" {
+	if tagName == "" || tagName == "mapstructure" {
 		return []string{"mapstructure"}
 	}
 	parts := strings.Split(tagName, ",")


### PR DESCRIPTION
Currently, mapstructure is often slower than just JSON-marshaling and unmarshaling again.

Adding some caches improves performance significantly.

```
goos: darwin
goarch: arm64
pkg: github.com/go-viper/mapstructure/v2
cpu: Apple M4
                              │ /tmp/msbench/baseline.txt │        /tmp/msbench/final.txt        │
                              │          sec/op           │    sec/op     vs base                │
_Decode-10                                   1.862µ ±  0%   1.637µ ±  5%  -12.08% (p=0.001 n=10)
_DecodeBasic-10                              7.804µ ±  4%   6.071µ ±  1%  -22.21% (p=0.000 n=10)
_DecodeEmbedded-10                           6.131µ ±  6%   3.721µ ±  2%  -39.31% (p=0.000 n=10)
_DecodeMapOfStruct-10                       11.847µ ±  1%   7.250µ ± 15%  -38.80% (p=0.002 n=10)
_DecodeSliceOfStruct-10                     11.593µ ±  9%   6.742µ ± 20%  -41.85% (p=0.000 n=10)
_DecodeMetadata-10                           1.569µ ± 12%   1.228µ ±  2%  -21.73% (p=0.000 n=10)
_DecodeMetadataEmbedded-10                   7.599µ ± 10%   5.769µ ±  3%  -24.09% (p=0.000 n=10)
_DecodeTagged-10                             817.2n ±  5%   582.4n ±  5%  -28.74% (p=0.000 n=10)
_DecodeWithRemainingFields-10                1.957µ ±  3%   1.841µ ±  1%   -5.95% (p=0.000 n=10)
geomean                                      3.949µ         2.882µ        -27.01%
```