### PR TITLE
fix: recurse into []*struct with Deep struct-to-map decoding (#196)

### DIFF
--- a/mapstructure.go
+++ b/mapstructure.go
@@ -1259,11 +1259,14 @@ func (d *Decoder) decodeMapFromStruct(name string, dataVal reflect.Value, val re
 		case reflect.Slice:
 			if deep {
 				var childType reflect.Type
-				switch v.Type().Elem().Kind() {
-				case reflect.Struct:
+				elemType := v.Type().Elem()
+				// Recurse into slices of structs and slices of pointers to
+				// structs alike, so []*T maps the same way []T does.
+				if elemType.Kind() == reflect.Struct ||
+					(elemType.Kind() == reflect.Ptr && elemType.Elem().Kind() == reflect.Struct) {
 					childType = reflect.TypeOf(map[string]any{})
-				default:
-					childType = v.Type().Elem()
+				} else {
+					childType = elemType
 				}
 
 				sType := reflect.SliceOf(childType)

--- a/mapstructure_test.go
+++ b/mapstructure_test.go
@@ -3865,6 +3865,7 @@ func TestDecode_structArrayDeepMap(t *testing.T) {
 	type SourceParent struct {
 		ChildrenA []SourceChild  `mapstructure:"children-a,deep"`
 		ChildrenB *[]SourceChild `mapstructure:"children-b,deep"`
+		ChildrenC []*SourceChild `mapstructure:"children-c,deep"`
 	}
 
 	var target map[string]any
@@ -3875,6 +3876,10 @@ func TestDecode_structArrayDeepMap(t *testing.T) {
 			{String: "two"},
 		},
 		ChildrenB: &[]SourceChild{
+			{String: "one"},
+			{String: "two"},
+		},
+		ChildrenC: []*SourceChild{
 			{String: "one"},
 			{String: "two"},
 		},
@@ -3890,6 +3895,10 @@ func TestDecode_structArrayDeepMap(t *testing.T) {
 			{"some-string": "two"},
 		},
 		"children-b": []map[string]any{
+			{"some-string": "one"},
+			{"some-string": "two"},
+		},
+		"children-c": []map[string]any{
 			{"some-string": "one"},
 			{"some-string": "two"},
 		},


### PR DESCRIPTION
Fixes #196.

## Problem

With `DecoderConfig.Deep` (or a `,deep` tag), struct-to-map decoding recurses into `[]MyStruct` and produces `[]map[string]any`, but a `[]*MyStruct` field is left as raw `[]*MyStruct` in the output map. The two slice shapes decode inconsistently.

Root cause is in `decodeMapFromStruct`'s `reflect.Slice` branch, which only recurses when the element `Kind` is `reflect.Struct`:

```go
switch v.Type().Elem().Kind() {
case reflect.Struct:
    childType = reflect.TypeOf(map[string]any{})
default:
    childType = v.Type().Elem()   // []*T lands here → copied verbatim
}
```

For `[]*T` the element `Kind` is `reflect.Ptr`, so it falls into `default` and the pointer elements are copied as-is.

## Fix

Treat a slice whose element is a pointer-to-struct the same as a slice of structs, mapping both to `[]map[string]any`. The existing `d.decode` call already dereferences the pointer elements, so no other change is needed.

## Test

Extended the existing `TestDecode_structArrayDeepMap` with a `ChildrenC []*SourceChild` field alongside the current `[]SourceChild` and `*[]SourceChild` cases. It fails before the change (`children-c` comes back as `[]*mapstructure.SourceChild`) and passes after (`[]map[string]any`).

## Verification (real runs, Go 1.24.6)

- **RED**: with the test but without the `mapstructure.go` change → `FAIL: TestDecode_structArrayDeepMap` (`children-c` = `[]*mapstructure.SourceChild{...}`).
- **GREEN**: with the fix → `PASS`.
- Full suite as CI runs it: `go test -race -shuffle=on ./...` → `ok github.com/go-viper/mapstructure/v2`.
- `gofmt -s`, `gofumpt`, and `go vet ./...` all clean.

## AI assistance disclosure

Prepared with an AI coding assistant; the root-cause analysis, fix, extended test, and the RED→GREEN + race/lint verification above were run against a real Go 1.24.6 toolchain, not generated.
